### PR TITLE
Add support for --shared_ceph_folder to cephadm bootstrap in provisioning scripts

### DIFF
--- a/multihost/Makefile
+++ b/multihost/Makefile
@@ -27,6 +27,6 @@ stop:
 provision:
 	${SCP_CMD} -r  ../resources root@mycephfs11:
 	${SCP_CMD} provision.sh root@mycephfs11:/tmp/provision.sh
-	${SSH_CMD} root@mycephfs11 "DEVEL_IMAGE=${DEVEL_IMAGE} SMB_IMAGE=${SMB_IMAGE} /bin/bash -x /tmp/provision.sh"
+	${SSH_CMD} root@mycephfs11 "DEVEL_IMAGE=${DEVEL_IMAGE} SMB_IMAGE=${SMB_IMAGE} CEPH_SHARED_FOLDER='${CEPH_SHARED_FOLDER}' /bin/bash -x /tmp/provision.sh"
 
 .PHONY: ssh vagrant copy_keys start stop provision

--- a/multihost/provision.sh
+++ b/multihost/provision.sh
@@ -51,7 +51,6 @@ do
 	sleep 5
 done
 
-ceph mgr module enable orchestrator
 ceph mgr module enable smb
 
 # Perform other tasks before creating smb resources

--- a/multihost/provision.sh
+++ b/multihost/provision.sh
@@ -7,7 +7,17 @@ export CEPHADM_IMAGE=${DEVEL_IMAGE}
 echo Using image $CEPHADM_IMAGE
 cephadm install ceph-common
 export HOST_IP=192.168.145.11
-cephadm bootstrap --mon-ip=${HOST_IP} --initial-dashboard-password="x"
+
+# Prepare base bootstrap command
+BOOTSTRAP_CMD="cephadm bootstrap --mon-ip=${HOST_IP} --initial-dashboard-password='x'"
+
+# Append --shared_ceph_folder if provided
+if [ ! -z "$CEPH_SHARED_FOLDER" ]; then
+    BOOTSTRAP_CMD="$BOOTSTRAP_CMD --shared_ceph_folder=$CEPH_SHARED_FOLDER"
+fi
+
+# Run the bootstrap command
+$BOOTSTRAP_CMD
 
 cat >/root/.ssh/config <<EOF
 Host mycephfs??

--- a/singlehost/Makefile
+++ b/singlehost/Makefile
@@ -27,6 +27,6 @@ stop:
 provision:
 	${SCP_CMD} -r  ../resources root@mycephfs11:
 	${SCP_CMD} provision.sh root@mycephfs11:/tmp/provision.sh
-	${SSH_CMD} root@mycephfs11 "DEVEL_IMAGE=${DEVEL_IMAGE} SMB_IMAGE=${SMB_IMAGE} /bin/bash -x /tmp/provision.sh"
+	${SSH_CMD} root@mycephfs11 "DEVEL_IMAGE=${DEVEL_IMAGE} SMB_IMAGE=${SMB_IMAGE} CEPH_SHARED_FOLDER='${CEPH_SHARED_FOLDER}' /bin/bash -x /tmp/provision.sh"
 
 .PHONY: ssh vagrant copy_keys start stop provision

--- a/singlehost/provision.sh
+++ b/singlehost/provision.sh
@@ -7,7 +7,16 @@ export CEPHADM_IMAGE=${DEVEL_IMAGE}
 echo Using image $CEPHADM_IMAGE
 cephadm install ceph-common
 export HOST_IP=192.168.145.11
-cephadm bootstrap --mon-ip=${HOST_IP} --initial-dashboard-password="x" --single-host-defaults
+# Prepare base bootstrap command
+BOOTSTRAP_CMD="cephadm bootstrap --mon-ip=${HOST_IP} --initial-dashboard-password='x'"
+
+# Append --shared_ceph_folder if provided
+if [ ! -z "$CEPH_SHARED_FOLDER" ]; then
+    BOOTSTRAP_CMD="$BOOTSTRAP_CMD --shared_ceph_folder=$CEPH_SHARED_FOLDER"
+fi
+
+# Run the bootstrap command
+$BOOTSTRAP_CMD
 
 cat >/root/.ssh/config <<EOF
 Host mycephfs??

--- a/singlehost/provision.sh
+++ b/singlehost/provision.sh
@@ -43,7 +43,6 @@ do
 	sleep 5
 done
 
-ceph mgr module enable orchestrator
 ceph mgr module enable smb
 
 # Perform other tasks before creating smb resources


### PR DESCRIPTION
Added support for passing `--shared-ceph-folder` to cephadm bootstrap in the provisioning scripts. You can now specify a local Ceph folder when running `make start` by providing `CEPH_SHARED_FOLDER`